### PR TITLE
Increase speed over 30x

### DIFF
--- a/AddAgents.go
+++ b/AddAgents.go
@@ -1,27 +1,25 @@
 package main
 
-
 //Imports required packages to run program
 import (
 	"fmt"
-	"time"
 	"math/rand"
+	"time"
 
 	"encoding/json"
+	"flag"
 	"log"
 	"os"
-	"flag"
 )
 
-
-func main(){
+func main() {
 	//Receives "input" and "num" command-line arguments
 	inputFileName := flag.String("input", "", "Data to parse")
 	NumAgents := flag.Int("num", 0, "Number of agents in simulation")
 	flag.Parse()
 
 	//Quits if inputFileName or NumAgents are empty
-	if *inputFileName == "" || *NumAgents == 0{
+	if *inputFileName == "" || *NumAgents == 0 {
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -43,41 +41,39 @@ func main(){
 	//De-seeds randomization to produce new values each iteration
 	rand.Seed(time.Now().UnixNano())
 
-
 	//Prints formatted String
 	fmt.Println("{")
-	fmt.Println("\t\"agents\": [")	
+	fmt.Println("\t\"agents\": [")
 
-	for  i := 1; i<=*NumAgents; i++ {
-		
+	for i := 1; i <= *NumAgents; i++ {
+
 		//Produces random start/destination locations and priority rankings
-		START_ID := random_int(2001,178154)
-		DEST_ID := random_int(2001,178154)
+		START_ID := random_int(2001, 178154)
+		DEST_ID := random_int(2001, 178154)
 
-		ENVIR := random_int(1,10)		
-		CST := random_int(1,10)
-		TIME := random_int(1,10)
+		ENVIR := random_int(1, 10)
+		CST := random_int(1, 10)
+		TIME := random_int(1, 10)
 
-		DEPART_TIME := rand.Float32()*3
-
+		DEPART_TIME := rand.Float32() * 3
 
 		//Produces new start/destination locations if START_ID == DEST_ID
-		for START_ID == DEST_ID{
-			START_ID = random_int(2001,178154)
-			DEST_ID = random_int(2001,178154)
+		for START_ID == DEST_ID {
+			START_ID = random_int(2001, 178154)
+			DEST_ID = random_int(2001, 178154)
 		}
-			
+
 		//Produces new start/destination locations if associated TOOLTIP does not exist
-		for get_TOOLTIP(places, START_ID) == "" || get_TOOLTIP(places, DEST_ID) == ""{
-			START_ID = random_int(2001,178154)
-			DEST_ID = random_int(2001,178154)
+		for get_TOOLTIP(places, START_ID) == "" || get_TOOLTIP(places, DEST_ID) == "" {
+			START_ID = random_int(2001, 178154)
+			DEST_ID = random_int(2001, 178154)
 		}
 
 		//Prints result
 		fmt.Printf("\t\t{ \"ID\": %v,  \"START\": \"%v\", ", i, get_TOOLTIP(places, START_ID))
 		fmt.Printf("\"DEST\": \"%v\", \"DEPART_TIME\": %v, ", get_TOOLTIP(places, DEST_ID), DEPART_TIME)
-		fmt.Printf(" \"ENVIR\": %v, \"CST\": %v, \"TIME\": %v }, \n", ENVIR, CST, TIME)	
-	} 
+		fmt.Printf(" \"ENVIR\": %v, \"CST\": %v, \"TIME\": %v }, \n", ENVIR, CST, TIME)
+	}
 
 	fmt.Println("\t]")
 	fmt.Println("}")
@@ -86,14 +82,14 @@ func main(){
 
 //Returns TOOLTIP of an intersection based on assocaited OBJECTID
 func get_TOOLTIP(data FeatureCollection, id int) string {
-	var return_ID = ""	
+	var return_ID = ""
 
 	for _, start := range data.Features {
-		if start.Properties.OBJECTID == id{
+		if start.Properties.OBJECTID == id {
 			return_ID = start.Properties.TOOLTIP
 		}
 	}
-	
+
 	return return_ID
 }
 
@@ -101,4 +97,3 @@ func get_TOOLTIP(data FeatureCollection, id int) string {
 func random_int(min int, max int) int {
 	return rand.Intn(max-min+1) + min
 }
- 

--- a/AddAgents.go
+++ b/AddAgents.go
@@ -38,6 +38,12 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Generate tooltip by id map
+	tooltipsById := make(map[int]string)
+	for _, feature := range places.Features {
+		tooltipsById[feature.Properties.OBJECTID] = feature.Properties.TOOLTIP
+	}
+
 	//De-seeds randomization to produce new values each iteration
 	rand.Seed(time.Now().UnixNano())
 
@@ -64,33 +70,20 @@ func main() {
 		}
 
 		//Produces new start/destination locations if associated TOOLTIP does not exist
-		for get_TOOLTIP(places, START_ID) == "" || get_TOOLTIP(places, DEST_ID) == "" {
+		for tooltipsById[START_ID] == "" || tooltipsById[DEST_ID] == "" {
 			START_ID = random_int(2001, 178154)
 			DEST_ID = random_int(2001, 178154)
 		}
 
 		//Prints result
-		fmt.Printf("\t\t{ \"ID\": %v,  \"START\": \"%v\", ", i, get_TOOLTIP(places, START_ID))
-		fmt.Printf("\"DEST\": \"%v\", \"DEPART_TIME\": %v, ", get_TOOLTIP(places, DEST_ID), DEPART_TIME)
+		fmt.Printf("\t\t{ \"ID\": %v,  \"START\": \"%v\", ", i, tooltipsById[START_ID])
+		fmt.Printf("\"DEST\": \"%v\", \"DEPART_TIME\": %v, ", tooltipsById[DEST_ID], DEPART_TIME)
 		fmt.Printf(" \"ENVIR\": %v, \"CST\": %v, \"TIME\": %v }, \n", ENVIR, CST, TIME)
 	}
 
 	fmt.Println("\t]")
 	fmt.Println("}")
 
-}
-
-//Returns TOOLTIP of an intersection based on assocaited OBJECTID
-func get_TOOLTIP(data FeatureCollection, id int) string {
-	var return_ID = ""
-
-	for _, start := range data.Features {
-		if start.Properties.OBJECTID == id {
-			return_ID = start.Properties.TOOLTIP
-		}
-	}
-
-	return return_ID
 }
 
 //Produces a random number from [min,max]

--- a/agent.go
+++ b/agent.go
@@ -1,6 +1,6 @@
 package main
 
-import "'strconv"
+import "strconv"
 
 type Agent interface {
 	Id() string

--- a/agent.go
+++ b/agent.go
@@ -11,18 +11,17 @@ type Agent interface {
 
 type agent struct {
 	ID int
-	
-	START_ID int 
-	DEST_ID int
-	DEPART_TIME int	
+
+	START_ID    int
+	DEST_ID     int
+	DEPART_TIME int
 
 	START_LOCATION string
-	DEST_LOCATION string	
+	DEST_LOCATION  string
 
 	ENVIR int
-	CST int
-	TIME int
-	
+	CST   int
+	TIME  int
 }
 
 func (a agent) Id() string {

--- a/edge.go
+++ b/edge.go
@@ -10,10 +10,10 @@ type Edge interface {
 }
 
 type edge struct {
-	weight float64
-	from string
-	to string
-	time int
+	weight   float64
+	from     string
+	to       string
+	time     int
 	capacity int
 }
 
@@ -39,4 +39,4 @@ func (e edge) AddAgent() {
 
 func (e edge) RemoveAgent() {
 	e.capacity = e.capacity - 1
-} 
+}

--- a/features.go
+++ b/features.go
@@ -10,7 +10,7 @@ type Feature struct {
 }
 
 type PropertyList struct {
-	TOOLTIP string
+	TOOLTIP  string
 	OBJECTID int
 }
 
@@ -21,5 +21,3 @@ func (p *PropertyList) get_TOOLTIP() string {
 func (p *PropertyList) get_OBJECTID() int {
 	return p.OBJECTID
 }
-
-


### PR DESCRIPTION
Running on 100,000 agents like so:

```bash
 time ./traffic_agents -input ~/docs/school/compfutur/project/0372aa1fb42a4e29adb9caadcfb210bb_9.geojson -num 100000
```
I have the following output:

Commit | Time to run
--- | ---
1e61323 | real	1m36.034s
1cb73af | real	0m2.692s

This is more than 96s/3s or more than roughly a 32x speed increase. This is accomplished by replacing the `get_TOOLTIP` function (which ran in O(n) time) with a map (O(1)).